### PR TITLE
Fix the app_catalog in circeci job definiton.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
       - architect/push-to-app-catalog:
           context: architect
           name: push-to-control-plane-app-catalog
-          app_catalog: "control-plane-test-catalog"
+          app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "cluster-api-provider-vsphere"
           filters:


### PR DESCRIPTION
The released version is pushed to the test catalog because of this error.
See https://app.circleci.com/pipelines/github/giantswarm/cluster-api-provider-vsphere-app/294/workflows/ae279c1f-14a4-4dc7-b496-79cc6e3fc8e2/jobs/294

