### PR TITLE
Remove rogue `creationTimestamp: "null"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove rogue `creationTimestamp: "null"`.
+
 ## [0.9.3] - 2023-05-17
+
+:warning: This release is broken. Please use 0.9.4 instead.
 
 ### Added
 

--- a/helm/cluster-api-provider-vsphere/files/vsphereclusteridentities.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vsphereclusteridentities.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
     controller-gen.kubebuilder.io/version: v0.7.0
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'


### PR DESCRIPTION
Somehow I introduced that with https://github.com/giantswarm/cluster-api-provider-vsphere-app/pull/56. I have no idea how I managed that.

Fixes:

```
$ k logs -n giantswarm cluster-api-provider-vsphere-crd-install-h9kzm
+ set -o nounset
+ kubectl apply -f /data/
customresourcedefinition.apiextensions.k8s.io/vsphereclusters.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vsphereclustertemplates.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vspheredeploymentzones.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vspherefailuredomains.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vspheremachines.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vspheremachinetemplates.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/vspherevms.infrastructure.cluster.x-k8s.io created
error: unable to decode "/data/vsphereclusteridentities.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```