### PR TITLE
Bump version from 1.8.9 to 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump CAPV from `1.8.9` to `1.9.3`.
+ 
 ## [0.11.0] - 2024-05-22
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 APPLICATION_NAME="cluster-api-provider-vsphere"
 
 UPSTREAM_ORG="kubernetes-sigs"
-TAG_TO_SYNC="v1.8.9"
+TAG_TO_SYNC="v1.9.3"
 
 OS ?= $(shell go env GOOS 2>/dev/null || echo linux)
 ARCH ?= $(shell go env GOARCH 2>/dev/null || echo amd64)

--- a/helm/cluster-api-provider-vsphere/files/vsphereclusteridentities.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vsphereclusteridentities.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -167,7 +167,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -300,7 +300,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -308,7 +308,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: VSphereClusterIdentity defines the account to be used for reconciling
-          clusters
+          clusters.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -323,6 +323,8 @@ spec:
           metadata:
             type: object
           spec:
+            description: VSphereClusterIdentitySpec contains a secret reference and
+              a group of allowed namespaces.
             properties:
               allowedNamespaces:
                 description: AllowedNamespaces is used to identify which namespaces
@@ -383,6 +385,7 @@ spec:
                 type: string
             type: object
           status:
+            description: VSphereClusterIdentityStatus contains the status of the VSphereClusterIdentity.
             properties:
               conditions:
                 description: Conditions defines current service state of the VSphereCluster.

--- a/helm/cluster-api-provider-vsphere/files/vsphereclusters.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vsphereclusters.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -77,11 +77,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereClusterSpec defines the desired state of VSphereCluster
+            description: VSphereClusterSpec defines the desired state of VSphereCluster.
             properties:
               cloudProviderConfiguration:
-                description: 'CloudProviderConfiguration holds the cluster-wide configuration
-                  for the DEPRECATED: will be removed in v1alpha4 vSphere cloud provider.'
+                description: "CloudProviderConfiguration holds the cluster-wide configuration
+                  for the vSphere cloud provider. \n Deprecated: will be removed in
+                  v1alpha4."
                 properties:
                   disk:
                     description: Disk is the vSphere cloud provider's disk configuration.
@@ -302,16 +303,16 @@ spec:
                 - name
                 type: object
               insecure:
-                description: 'Insecure is a flag that controls whether or not to validate
-                  the vSphere server''s certificate. DEPRECATED: will be removed in
-                  v1alpha4'
+                description: "Insecure is a flag that controls whether to validate
+                  the vSphere server's certificate. \n Deprecated: will be removed
+                  in v1alpha4."
                 type: boolean
               loadBalancerRef:
-                description: 'LoadBalancerRef may be used to enable a control plane
+                description: "LoadBalancerRef may be used to enable a control plane
                   load balancer for this cluster. When a LoadBalancerRef is provided,
                   the VSphereCluster.Status.Ready field will not be true until the
                   referenced resource is Status.Ready and has a non-empty Status.Address
-                  value. DEPRECATED: will be removed in v1alpha4'
+                  value. \n Deprecated: will be removed in v1alpha4."
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -357,7 +358,7 @@ spec:
                 type: string
             type: object
           status:
-            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec.
             properties:
               conditions:
                 description: Conditions defines current service state of the VSphereCluster.
@@ -427,7 +428,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -584,7 +585,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -609,7 +610,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VSphereCluster is the Schema for the vsphereclusters API
+        description: VSphereCluster is the Schema for the vsphereclusters API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -624,7 +625,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereClusterSpec defines the desired state of VSphereCluster
+            description: VSphereClusterSpec defines the desired state of VSphereCluster.
             properties:
               clusterModules:
                 description: ClusterModules hosts information regarding the anti-affinity
@@ -748,7 +749,7 @@ spec:
                 type: string
             type: object
           status:
-            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec.
             properties:
               conditions:
                 description: Conditions defines current service state of the VSphereCluster.

--- a/helm/cluster-api-provider-vsphere/files/vsphereclustertemplates.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vsphereclustertemplates.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -116,13 +116,13 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta1
     schema:
       openAPIV3Schema:
         description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -137,12 +137,14 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereClusterTemplateSpec defines the desired state of VSphereClusterTemplate
+            description: VSphereClusterTemplateSpec defines the desired state of VSphereClusterTemplate.
             properties:
               template:
+                description: VSphereClusterTemplateResource describes the data for
+                  creating a VSphereCluster from a template.
                 properties:
                   spec:
-                    description: VSphereClusterSpec defines the desired state of VSphereCluster
+                    description: VSphereClusterSpec defines the desired state of VSphereCluster.
                     properties:
                       clusterModules:
                         description: ClusterModules hosts information regarding the

--- a/helm/cluster-api-provider-vsphere/files/vspheredeploymentzones.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vspheredeploymentzones.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -140,7 +140,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -245,7 +245,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -253,7 +253,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -268,7 +268,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone.
             properties:
               controlPlane:
                 description: ControlPlane determines if this failure domain is suitable
@@ -298,6 +298,7 @@ spec:
             - placementConstraint
             type: object
           status:
+            description: VSphereDeploymentZoneStatus contains the status for a VSphereDeploymentZone.
             properties:
               conditions:
                 description: Conditions defines current service state of the VSphereMachine.

--- a/helm/cluster-api-provider-vsphere/files/vspherefailuredomains.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vspherefailuredomains.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -159,7 +159,7 @@ spec:
             - zone
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - deprecated: true
     name: v1alpha4
@@ -281,13 +281,13 @@ spec:
             - zone
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta1
     schema:
       openAPIV3Schema:
         description: VSphereFailureDomain is the Schema for the vspherefailuredomains
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -302,7 +302,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain.
             properties:
               region:
                 description: Region defines the name and type of a region

--- a/helm/cluster-api-provider-vsphere/files/vspheremachines.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vspheremachines.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -433,7 +433,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -831,7 +831,7 @@ spec:
                 type: boolean
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -860,7 +860,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VSphereMachine is the Schema for the vspheremachines API
+        description: VSphereMachine is the Schema for the vspheremachines API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -875,7 +875,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereMachineSpec defines the desired state of VSphereMachine
+            description: VSphereMachineSpec defines the desired state of VSphereMachine.
             properties:
               additionalDisksGiB:
                 description: AdditionalDisksGiB holds the sizes of additional disks
@@ -1226,7 +1226,7 @@ spec:
                 description: PciDevices is the list of pci devices used by the virtual
                   machine.
                 items:
-                  description: PCIDeviceSpec defines virtual machine's PCI configuration
+                  description: PCIDeviceSpec defines virtual machine's PCI configuration.
                   properties:
                     deviceId:
                       description: DeviceID is the device ID of a virtual machine's
@@ -1302,7 +1302,7 @@ spec:
             - template
             type: object
           status:
-            description: VSphereMachineStatus defines the observed state of VSphereMachine
+            description: VSphereMachineStatus defines the observed state of VSphereMachine.
             properties:
               addresses:
                 description: Addresses contains the VSphere instance associated addresses.

--- a/helm/cluster-api-provider-vsphere/files/vspheremachinetemplates.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vspheremachinetemplates.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -417,7 +417,7 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - deprecated: true
     name: v1alpha4
@@ -708,13 +708,13 @@ spec:
             - template
             type: object
         type: object
-    served: true
+    served: false
     storage: false
   - name: v1beta1
     schema:
       openAPIV3Schema:
         description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
-          API
+          API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -729,11 +729,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate.
             properties:
               template:
                 description: VSphereMachineTemplateResource describes the data needed
-                  to create a VSphereMachine from a template
+                  to create a VSphereMachine from a template.
                 properties:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
@@ -1135,7 +1135,7 @@ spec:
                           the virtual machine.
                         items:
                           description: PCIDeviceSpec defines virtual machine's PCI
-                            configuration
+                            configuration.
                           properties:
                             deviceId:
                               description: DeviceID is the device ID of a virtual

--- a/helm/cluster-api-provider-vsphere/files/vspherevms.yaml
+++ b/helm/cluster-api-provider-vsphere/files/vspherevms.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capv-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.12.1
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
     app.kubernetes.io/managed-by: '{{ .Release.Service }}'
@@ -62,10 +62,9 @@ spec:
             description: VSphereVMSpec defines the desired state of VSphereVM.
             properties:
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -449,7 +448,7 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
@@ -476,10 +475,9 @@ spec:
             description: VSphereVMSpec defines the desired state of VSphereVM.
             properties:
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -863,14 +861,14 @@ spec:
                 type: string
             type: object
         type: object
-    served: true
+    served: false
     storage: false
     subresources:
       status: {}
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: VSphereVM is the Schema for the vspherevms API
+        description: VSphereVM is the Schema for the vspherevms API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -896,10 +894,9 @@ spec:
                   type: integer
                 type: array
               biosUUID:
-                description: BiosUUID is the the VM's BIOS UUID that is assigned at
-                  runtime after the VM has been created. This field is required at
-                  runtime for other controllers that read this CRD as unstructured
-                  data.
+                description: BiosUUID is the VM's BIOS UUID that is assigned at runtime
+                  after the VM has been created. This field is required at runtime
+                  for other controllers that read this CRD as unstructured data.
                 type: string
               bootstrapRef:
                 description: BootstrapRef is a reference to a bootstrap provider-specific
@@ -1275,7 +1272,7 @@ spec:
                 description: PciDevices is the list of pci devices used by the virtual
                   machine.
                 items:
-                  description: PCIDeviceSpec defines virtual machine's PCI configuration
+                  description: PCIDeviceSpec defines virtual machine's PCI configuration.
                   properties:
                     deviceId:
                       description: DeviceID is the device ID of a virtual machine's
@@ -1347,7 +1344,7 @@ spec:
             - template
             type: object
           status:
-            description: VSphereVMStatus defines the observed state of VSphereVM
+            description: VSphereVMStatus defines the observed state of VSphereVM.
             properties:
               addresses:
                 description: Addresses is a list of the VM's IP addresses. This field
@@ -1486,7 +1483,7 @@ spec:
                   not be set or modified by users.
                 type: string
               vmRef:
-                description: VMRef is the the VM's Managed Object Reference on vSphere.
+                description: VMRef is the VM's Managed Object Reference on vSphere.
                   It can be used by consumers to programatically get this VM representation
                   on vSphere in case of the need to retrieve informations. This field
                   is set once the machine is created and should not be changed

--- a/helm/cluster-api-provider-vsphere/templates/apps_v1_deployment_capv-controller-manager.yaml
+++ b/helm/cluster-api-provider-vsphere/templates/apps_v1_deployment_capv-controller-manager.yaml
@@ -44,6 +44,9 @@ spec:
             - containerPort: 9440
               name: healthz
               protocol: TCP
+            - containerPort: 8443
+              name: metrics
+              protocol: TCP
           readinessProbe:
             httpGet:
               path: /readyz

--- a/helm/cluster-api-provider-vsphere/templates/rbac.authorization.k8s.io_v1_clusterrole_capv-manager-role.yaml
+++ b/helm/cluster-api-provider-vsphere/templates/rbac.authorization.k8s.io_v1_clusterrole_capv-manager-role.yaml
@@ -108,6 +108,18 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/helm/cluster-api-provider-vsphere/values.yaml
+++ b/helm/cluster-api-provider-vsphere/values.yaml
@@ -1,6 +1,6 @@
 image:
   name: gsoci.azurecr.io/giantswarm/cluster-api-vsphere-controller
-  tag: v1.8.9
+  tag: v1.9.3
 
 project:
   branch: ""


### PR DESCRIPTION
Bump CAPV 1.8.9 to 1.9.3

Tested in gravel. 

### Testing

- [x] fresh install works
- [x] upgrade from previous version works

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
- [ ] Update lastpass values if required.