### PR TITLE
Chart: Remove deprecated flag `--enable-keep-alive`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Remove deprecated flag `--enable-keep-alive`.
+
 ## [0.14.0] - 2025-08-13
 
 ### Changed

--- a/config/kustomize/patches/deployment-resources.yaml
+++ b/config/kustomize/patches/deployment-resources.yaml
@@ -23,7 +23,6 @@ spec:
           - --leader-elect
           - --v=6
           - --feature-gates=NodeAntiAffinity=false
-          - --enable-keep-alive=false
           resources:
             limits:
               cpu: "{{ .Values.resources.limits.cpu }}"

--- a/helm/cluster-api-provider-vsphere/templates/apps_v1_deployment_capv-controller-manager.yaml
+++ b/helm/cluster-api-provider-vsphere/templates/apps_v1_deployment_capv-controller-manager.yaml
@@ -30,7 +30,6 @@ spec:
             - --leader-elect
             - --v=6
             - --feature-gates=NodeAntiAffinity=false
-            - --enable-keep-alive=false
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
The new version of the controller does not support flag `--enable-keep-alive` and makes the pod crash.

```
> kubectl logs -n giantswarm         capv-controller-manager-556db49d44-fb2f5
unknown flag: --enable-keep-alive
Usage of /manager:
```

https://gigantic.slack.com/archives/C01BYMF6RN0/p1755183759673349