### PR TITLE
Chart: Downgrade `kubectl` to an existing image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Chart: Remove deprecated flag `--enable-keep-alive`.
+- Chart: Downgrade `kubectl` to an existing image.
 
 ## [0.14.0] - 2025-08-13
 

--- a/helm/cluster-api-provider-vsphere/README.md
+++ b/helm/cluster-api-provider-vsphere/README.md
@@ -28,7 +28,7 @@ A Helm chart for cluster api provider vsphere
 | crdInstall.enable | bool | `true` |  |
 | crdInstall.kubectl.image | string | `"giantswarm/kubectl"` |  |
 | crdInstall.kubectl.registry | string | `"gsoci.azurecr.io"` |  |
-| crdInstall.kubectl.tag | string | `"1.31.11"` |  |
+| crdInstall.kubectl.tag | string | `"1.31.4"` |  |
 | global.podSecurityStandards.enforced | bool | `false` |  |
 | image.name | string | `"gsoci.azurecr.io/giantswarm/cluster-api-vsphere-controller"` |  |
 | image.tag | string | `"v1.12.1"` |  |

--- a/helm/cluster-api-provider-vsphere/values.yaml
+++ b/helm/cluster-api-provider-vsphere/values.yaml
@@ -9,9 +9,9 @@ project:
 crdInstall:
   enable: true
   kubectl:
-    image: "giantswarm/kubectl"
+    image: giantswarm/kubectl
     registry: gsoci.azurecr.io
-    tag: 1.31.11
+    tag: 1.31.4
 
 ciliumNetworkPolicy:
   enabled: false


### PR DESCRIPTION
I wasn't aware we are using `bitnami/kubectl` and assumed I could just use a recent Kubernetes version. But apparently Bitnami does not have the exact same tags as Kubernetes...