### PR TITLE
chore: standardize vSphere app icon on light variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update vSphere app icon to the light variant (`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`).
+
 ## [2.1.2] - 2026-03-04
 
 ### Changed

--- a/helm/cluster-api-provider-vsphere/Chart.yaml
+++ b/helm/cluster-api-provider-vsphere/Chart.yaml
@@ -4,7 +4,7 @@ version: 2.1.2
 appVersion: v1.13.1
 description: A Helm chart for cluster api provider vsphere
 home: https://github.com/giantswarm/cluster-api-provider-vsphere-app
-icon: https://s.giantswarm.io/app-icons/vsphere/2/icon-dark.png
+icon: https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png
 sources:
   - https://github.com/giantswarm/cluster-api-provider-vsphere-app
 annotations:


### PR DESCRIPTION
Standardizes the vSphere app icon on the **light** variant, matching the other vSphere charts (`cluster-vsphere`, `cloud-provider-vsphere-app`, `cluster-nutanix`):

`https://s.giantswarm.io/app-icons/vsphere/2/icon-light.png`

This chart was still on `icon-dark.png`. The `vsphere/2` icon set is already live, so there is no rollout dependency.
